### PR TITLE
Added DataAwareApplicationMaster

### DIFF
--- a/java/common/src/main/java/com/cloudera/kitten/ContainerLaunchContextFactory.java
+++ b/java/common/src/main/java/com/cloudera/kitten/ContainerLaunchContextFactory.java
@@ -48,7 +48,7 @@ public class ContainerLaunchContextFactory {
     req.setCapability(parameters.getContainerResource(clusterMin, clusterMax));
     req.setPriority(createPriority(parameters.getPriority()));
     req.setNumContainers(parameters.getNumInstances());
-    req.setHostName("*"); // TODO: get smarter about this.
+    req.setHostName(parameters.getDesiredHostname()); //TODO: get smarter about this
     return req;
   }
   

--- a/java/common/src/main/java/com/cloudera/kitten/ContainerLaunchParameters.java
+++ b/java/common/src/main/java/com/cloudera/kitten/ContainerLaunchParameters.java
@@ -17,6 +17,7 @@ package com.cloudera.kitten;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.Resource;
 
@@ -54,7 +55,19 @@ public interface ContainerLaunchParameters {
    * The local resources for the application in the container.
    */
   Map<String, LocalResource> getLocalResources();
-  
+
+  /**
+   * The HDFS paths that are expected to be accessed by the container (for data locality)
+   * Not to be confused with a LocalResource whose initial location is on HDFS
+   */
+  List<Path> getHDFSResources();
+
+  /**
+   * The desired hostname/rack
+   */
+  String getDesiredHostname();
+  void setDesiredHostname(String host);
+
   /**
    * The environment variables for the container.
    */

--- a/java/common/src/main/java/com/cloudera/kitten/lua/LuaContainerLaunchParameters.java
+++ b/java/common/src/main/java/com/cloudera/kitten/lua/LuaContainerLaunchParameters.java
@@ -141,6 +141,29 @@ public class LuaContainerLaunchParameters implements ContainerLaunchParameters {
     return localResources;
   }
 
+  @Override
+  public List<Path> getHDFSResources() {
+    List<Path> resourcePaths = Lists.newArrayList();
+    if (!lv.isNil(LuaFields.DESIRED_LOCALITY_NEAR_HDFS_FILES)) {
+      LuaWrapper lr = lv.getTable(LuaFields.DESIRED_LOCALITY_NEAR_HDFS_FILES);
+      for (LuaPair lp : lr) {
+        Path p = new Path(lp.value.tojstring());
+        resourcePaths.add(p);
+      }
+    }
+    return resourcePaths;
+  }
+
+  @Override
+  public String getDesiredHostname() {
+    return lv.isNil(LuaFields.DESIRED_HOSTNAME) ? "*" : lv.getString(LuaFields.DESIRED_HOSTNAME);
+  }
+
+  @Override
+  public void setDesiredHostname(String host) {
+    lv.setString(LuaFields.DESIRED_HOSTNAME, host);
+  }
+
   private LocalResource constructExtraResource(String key) {
     LocalResource rsrc = Records.newRecord(LocalResource.class);
     rsrc.setType(LocalResourceType.FILE);

--- a/java/common/src/main/java/com/cloudera/kitten/lua/LuaFields.java
+++ b/java/common/src/main/java/com/cloudera/kitten/lua/LuaFields.java
@@ -36,6 +36,8 @@ public class LuaFields {
   public static final String INSTANCES = "instances";
   public static final String MEMORY = "memory";
   public static final String PRIORITY = "priority";
+  public static final String DESIRED_HOSTNAME = "desired_hostname";
+  public static final String DESIRED_LOCALITY_NEAR_HDFS_FILES = "near_hdfs";
 
   // For constructing commands from a LuaTable.
   public static final String COMMAND_BASE = "base";

--- a/java/master/src/main/java/com/cloudera/kitten/appmaster/DataAwareApplicationMaster.java
+++ b/java/master/src/main/java/com/cloudera/kitten/appmaster/DataAwareApplicationMaster.java
@@ -1,0 +1,22 @@
+package com.cloudera.kitten.appmaster;
+
+import com.cloudera.kitten.appmaster.params.lua.LuaApplicationMasterParameters;
+import com.cloudera.kitten.appmaster.service.DataAwareApplicationMasterServiceImpl;
+
+public class DataAwareApplicationMaster extends ApplicationMaster {
+
+  @Override
+  public int run(String[] args) throws Exception {
+    ApplicationMasterParameters params = new LuaApplicationMasterParameters(getConf());
+    ApplicationMasterService service = new DataAwareApplicationMasterServiceImpl(params);
+    
+    service.startAndWait();
+    while (service.isRunning()) {
+      Thread.sleep(1000);
+    }
+    
+    System.exit(0);
+    return 0;
+  }
+  
+}

--- a/java/master/src/main/java/com/cloudera/kitten/appmaster/service/ApplicationMasterServiceImpl.java
+++ b/java/master/src/main/java/com/cloudera/kitten/appmaster/service/ApplicationMasterServiceImpl.java
@@ -61,17 +61,17 @@ import com.google.common.util.concurrent.AbstractScheduledService;
 public class ApplicationMasterServiceImpl extends
     AbstractScheduledService implements ApplicationMasterService {
 
-  private static final Log LOG = LogFactory.getLog(ApplicationMasterServiceImpl.class);
+  protected static final Log LOG = LogFactory.getLog(ApplicationMasterServiceImpl.class);
 
-  private final ApplicationMasterParameters parameters;
-  private final MasterConnectionFactory<AMRMProtocol> resourceManagerFactory;
+  protected final ApplicationMasterParameters parameters;
+  protected final MasterConnectionFactory<AMRMProtocol> resourceManagerFactory;
   private final ContainerManagerConnectionFactory containerManagerFactory;
-  private final List<ContainerTracker> containerTrackers;
+  protected final List<ContainerTracker> containerTrackers;
   private final AtomicInteger newRequestId = new AtomicInteger();
   private final AtomicInteger totalFailures = new AtomicInteger();
   
-  private AMRMProtocol resourceManager;
-  private ContainerLaunchContextFactory containerLaunchContextFactory;
+  protected AMRMProtocol resourceManager;
+  protected ContainerLaunchContextFactory containerLaunchContextFactory;
   
   public ApplicationMasterServiceImpl(ApplicationMasterParameters params) {
     this(params, new ResourceManagerConnectionFactory(params.getConfiguration()),
@@ -140,7 +140,7 @@ public class ApplicationMasterServiceImpl extends
     }
   }
   
-  private RegisterApplicationMasterRequest createRegistrationRequest() {
+  protected RegisterApplicationMasterRequest createRegistrationRequest() {
     RegisterApplicationMasterRequest req = Records.newRecord(
         RegisterApplicationMasterRequest.class);
     req.setApplicationAttemptId(parameters.getApplicationAttemptId());
@@ -196,7 +196,7 @@ public class ApplicationMasterServiceImpl extends
     }
   }
   
-  private class ContainerTracker {
+  class ContainerTracker {
     private final ContainerLaunchParameters parameters;
     private final int needed;
     private final Map<ContainerId, ContainerService> services;

--- a/java/master/src/main/java/com/cloudera/kitten/appmaster/service/DataAwareApplicationMasterServiceImpl.java
+++ b/java/master/src/main/java/com/cloudera/kitten/appmaster/service/DataAwareApplicationMasterServiceImpl.java
@@ -1,0 +1,88 @@
+package com.cloudera.kitten.appmaster.service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
+import org.apache.hadoop.yarn.exceptions.YarnRemoteException;
+
+import com.cloudera.kitten.ContainerLaunchContextFactory;
+import com.cloudera.kitten.ContainerLaunchParameters;
+import com.cloudera.kitten.appmaster.ApplicationMasterParameters;
+import com.cloudera.kitten.appmaster.util.HDFSFileFinder;
+
+public class DataAwareApplicationMasterServiceImpl extends
+    ApplicationMasterServiceImpl {
+
+  public DataAwareApplicationMasterServiceImpl(
+      ApplicationMasterParameters params) {
+    super(params);
+  }
+  
+  
+  @Override
+  protected void startUp() {
+    super.resourceManager = resourceManagerFactory.connect();
+    
+    RegisterApplicationMasterResponse registration = null;
+    try {
+      registration = resourceManager.registerApplicationMaster(createRegistrationRequest());
+    } catch (YarnRemoteException e) {
+      LOG.error("Exception thrown registering application master", e);
+      stop();
+      return;
+    }
+    
+    this.containerLaunchContextFactory = new ContainerLaunchContextFactory(
+        registration.getMinimumResourceCapability(), registration.getMaximumResourceCapability());
+    
+    List<ContainerLaunchParameters> containerParameters = parameters.getContainerLaunchParameters();
+    
+    HDFSFileFinder ff = new HDFSFileFinder();
+    
+    // simple data-aware logic
+    //   1. look at first HDFS resource
+    //   2. find the host with the most
+    //   3. set the desired host
+    //
+    // TODO: only decides based on the first file, could be much smarter
+    
+    for (ContainerLaunchParameters params : containerParameters) {
+      if (params.getHDFSResources().isEmpty()) {
+        continue;
+      }
+      else {
+        Path p = params.getHDFSResources().get(0);
+        String hostessWithTheMostess = "*";
+        try {
+          Map<String, Long> numBytes = ff.getNumBytesOfGlobHeldByDatanodes(p);
+          long most = -1L;
+          for (String k : numBytes.keySet()) {
+            long b = numBytes.get(k);
+            if (b > most) {
+              most = b;
+              hostessWithTheMostess = k;
+            }
+          }
+        } catch (IOException e) {
+          LOG.error("Trouble communicating with HDFS. Defaulting to any host for this container.");
+          hostessWithTheMostess = "*";
+        }
+        params.setDesiredHostname(hostessWithTheMostess);
+      }
+    }
+    
+    if (containerParameters.isEmpty()) {
+      LOG.warn("No container configurations specified");
+      stop();
+      return;
+    }
+    for (int i = 0; i < containerParameters.size(); i++) {
+      ContainerLaunchParameters clp = containerParameters.get(i);
+      containerTrackers.add(new ContainerTracker(clp));
+    }
+  }
+
+}


### PR DESCRIPTION
A new parameter for containers: `hdfs_files = { "hdfs/path/1", "hdfs/path/2" }`

This allows specifying a hint of which files the application will access from hdfs.

The DataAwareApplicationMaster then sets the appropriate desired host based on this hint.  Right now the strategy is very simple but can be improved later.

Also, I'm having some trouble devising a test for this.
