### PR TITLE
distshell test fails with leading slash

### DIFF
--- a/java/client/src/test/java/com/cloudera/kitten/TestKittenDistributedShell.java
+++ b/java/client/src/test/java/com/cloudera/kitten/TestKittenDistributedShell.java
@@ -67,7 +67,7 @@ public class TestKittenDistributedShell {
   
   @Test
   public void testKittenShell() throws Exception {
-    String config = "/lua/distshell.lua";
+    String config = "lua/distshell.lua";
 
     // For the outputs
     File tmpFile = File.createTempFile("distshell", ".txt");


### PR DESCRIPTION
Without this tiny change, when running mvn test for client I get /lua/distshell.lua not found.

```
Running com.cloudera.kitten.TestKittenDistributedShell
0    [main] INFO  com.cloudera.kitten.TestKittenDistributedShell  - Starting up YARN cluster
log4j:WARN No appenders could be found for logger (org.mortbay.log).
log4j:WARN Please initialize the log4j system properly.
Jul 2, 2012 3:11:54 PM com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory register
INFO: Registering org.apache.hadoop.yarn.server.resourcemanager.webapp.JAXBContextResolver as a provider class
Jul 2, 2012 3:11:54 PM com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory register
INFO: Registering org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWebServices as a root resource class
Jul 2, 2012 3:11:54 PM com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory register
INFO: Registering org.apache.hadoop.yarn.webapp.GenericExceptionHandler as a provider class
Jul 2, 2012 3:11:54 PM com.sun.jersey.server.impl.application.WebApplicationImpl _initiate
INFO: Initiating Jersey application, version 'Jersey: 1.8 06/24/2011 12:17 PM'
Jul 2, 2012 3:11:54 PM com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory getComponentProvider
INFO: Binding org.apache.hadoop.yarn.server.resourcemanager.webapp.JAXBContextResolver to GuiceManagedComponentProvider with the scope "Singleton"
Jul 2, 2012 3:11:54 PM com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory getComponentProvider
INFO: Binding org.apache.hadoop.yarn.webapp.GenericExceptionHandler to GuiceManagedComponentProvider with the scope "Singleton"
Jul 2, 2012 3:11:55 PM com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory getComponentProvider
INFO: Binding org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWebServices to GuiceManagedComponentProvider with the scope "Singleton"
Jul 2, 2012 3:11:55 PM com.google.inject.servlet.GuiceFilter setPipeline
WARNING: Multiple Servlet injectors detected. This is a warning indicating that you have more than one GuiceFilter running in your web application. If this is deliberate, you may safely ignore this message. If this is NOT deliberate however, your application may not work as expected.
7244 [Thread[Thread-13,5,main]] ERROR org.apache.hadoop.security.token.delegation.AbstractDelegationTokenSecretManager  - InterruptedExcpetion recieved for ExpiredTokenRemover thread java.lang.InterruptedException: sleep interrupted
7268 [ResourceManager Event Processor] ERROR org.apache.hadoop.yarn.server.resourcemanager.ResourceManager  - Returning, interrupted : java.lang.InterruptedException
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 7.293 sec <<< FAILURE!

Results :

Tests in error: 
  testKittenShell(com.cloudera.kitten.TestKittenDistributedShell): resource /lua/distshell.lua not found.
```
